### PR TITLE
chore: only include lib in published module

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
   },
   "peerDependencies": {
     "react": "^15.6.1"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
Currently, the published contains dev files:

```shell
node_modules/react-offline-hoc
├── .babelrc
├── .ci
│   └── test.sh
├── .eslintrc
├── example
│   ├── app.js
│   ├── .babelrc
│   ├── entry.js
│   ├── index.html
│   ├── package.json
│   ├── webpack.config.js
│   └── yarn.lock
├── .idea
│   ├── inspectionProfiles
│   │   └── Project_Default.xml
│   ├── misc.xml
│   ├── modules.xml
│   ├── react-offline-hoc.iml
│   ├── vcs.xml
│   └── workspace.xml
├── lib
│   ├── LICENSE
│   ├── offline.js
│   ├── package.json
│   └── README.md
├── LICENSE
├── package.json
├── README.md
├── src
│   └── offline.js
├── .travis.yml
└── yarn.lock

6 directories, 26 files
```

Not only does this increase the package size, it can also cause problems
with some build tools, such as Rollup, which loads `.babelrc` when it
doesn't need to (`lib` already contains transpiled code):

```
rollup -c
🚨   (babel plugin) Error: Couldn't find preset "stage-0" relative to directory "/home/travis/build/tlvince/app/node_modules/react-offline-hoc"
node_modules/react-offline-hoc/lib/offline.js
```